### PR TITLE
Fix the problem of common.xacro

### DIFF
--- a/lwr_description/urdf/common.xacro
+++ b/lwr_description/urdf/common.xacro
@@ -6,17 +6,17 @@
 
   <!-- Gazebo macro to define the inertia matrix needed for links.-->
   <macro name="cuboid_inertia_def" params="width height length mass">
-    <inertia ixx="${mass * (height * height + length * length) / 12)}"
-             iyy="${mass * (width  * width  + length * length) / 12)}"
-             izz="${mass * (width  * width  + height * height) / 12)}"
+    <inertia ixx="${mass * (height * height + length * length) / 12}"
+             iyy="${mass * (width  * width  + length * length) / 12}"
+             izz="${mass * (width  * width  + height * height) / 12}"
              ixy="0" iyz="0" ixz="0"/>
   </macro>
 
   <!-- length is along the y-axis! -->
   <macro name="cylinder_inertia_def" params="radius length mass">
-    <inertia ixx="${mass * (3 * radius * radius + length * length) / 12)}"
+    <inertia ixx="${mass * (3 * radius * radius + length * length) / 12}"
              iyy="${mass * (    radius * radius / 2)}"
-             izz="${mass * (3 * radius * radius + length * length) / 12)}"
+             izz="${mass * (3 * radius * radius + length * length) / 12}"
              ixy="0" iyz="0" ixz="0"/>
   </macro>
 


### PR DESCRIPTION
There's an extra ')' on "${mass * (height * height + length * length) / 12)}" and I had fix it to "${mass * (height * height + length * length) / 12}"